### PR TITLE
Add streaming materialized view pattern example (smv)

### DIFF
--- a/example_processors/smv/README.md
+++ b/example_processors/smv/README.md
@@ -1,8 +1,8 @@
 # Streaming Materialized View: Support Queue Dashboard
 
-This example demonstrates a streaming materialized view built with Atlas Stream Processing (ASP). A `queue_stats` collection is continuously maintained in near real-time as support tickets are opened, resolved, escalated, and deleted — with no manual refresh required.
+This example demonstrates the Streaming Materialized View Pattern using Atlas Stream Processing (ASP). A `queue_stats` collection is continuously maintained in near real-time as support tickets are opened, resolved, escalated, and deleted — with no manual refresh required.
 
-For conceptual background and a discussion of when streaming materialized views are preferable to the incremental approach, see [streaming-materialized-views.md](streaming-materialized-views.md).
+For conceptual background and a discussion of when this pattern is preferable to the on-demand approach, see [streaming-materialized-views.md](streaming-materialized-views.md).
 
 ---
 
@@ -58,7 +58,7 @@ mongoimport --uri "<connection-string>" --db support --collection sample_tickets
 
 ### `queue_stats` document shape
 
-One document per priority level. `open_count` is a running total maintained by the stream processor — it is never recomputed from scratch.
+One document per priority level. `open_count` is a running total maintained by the stream processor — a key characteristic of this pattern. It is never recomputed from scratch; only the incremental change from each event is applied.
 
 ```json
 { "_id": "P1", "open_count": 3 }
@@ -151,7 +151,7 @@ Run a one-time aggregation to compute the initial open ticket counts from the lo
 load("seed.mongodb.js");
 ```
 
-This creates `queue_stats` as an on-demand materialized view — a point-in-time snapshot of open ticket counts by priority. It will go stale the moment tickets change.
+This seeds `queue_stats` using the on-demand materialized view approach — a point-in-time snapshot of open ticket counts by priority. It will go stale the moment tickets change.
 
 ### Step 3 — Start the processor
 
@@ -162,7 +162,7 @@ load("pipelines/escalation-pipeline.mongodb.js");
 sp.queue_stats_escalation.start();
 ```
 
-Starting the processor converts `queue_stats` from an on-demand materialized view into a streaming materialized view — kept current continuously as tickets are inserted, resolved, escalated, and deleted.
+Starting the processor converts `queue_stats` from a point-in-time snapshot into a continuously maintained implementation of the Streaming Materialized View Pattern — kept current as tickets are inserted, resolved, escalated, and deleted.
 
 ### Step 4 — Watch the view
 
@@ -225,7 +225,7 @@ This stops and drops whichever SMV processor is running, then drops `support_tic
 
 ## Simplified Variant
 
-`pipelines/simple-pipeline.mongodb.js` handles three event types (insert, resolve, delete) and omits the escalation case. It uses a scalar `_delta` field and a `$match` stage to drop noise events, making it easier to follow as an introduction to the pattern. Use `activity/simple-activity.js` with this pipeline.
+`pipelines/simple-pipeline.mongodb.js` is a simpler implementation of the same pattern. It handles three event types (insert, resolve, delete) and omits the escalation case. It uses a scalar `_delta` field and a `$match` stage to drop noise events, making it easier to follow as an introduction to the pipeline design. Use `activity/simple-activity.js` with this pipeline.
 
 In your **ASP session**:
 
@@ -242,6 +242,7 @@ sp.queue_stats_simple.start();
 smv/
 ├── streaming-materialized-views.md         # Conceptual overview
 ├── README.md                               # This file
+├── TODO.md                                 # Planned extensions
 ├── seed.mongodb.js                         # Seed queue_stats from existing tickets (DB session)
 ├── reset-asp.mongodb.js                    # Stop and drop the stream processor (ASP session)
 ├── reset-db.mongodb.js                     # Drop all collections (DB session)

--- a/example_processors/smv/activity/escalation-activity.js
+++ b/example_processors/smv/activity/escalation-activity.js
@@ -1,9 +1,9 @@
-// activity-escalation.mongodb.js — Support queue activity simulator with escalations
+// escalation-activity.js — Support queue activity simulator with escalations
 //
-// Extends activity.mongodb.js with a fourth event type: priority escalation.
-// An escalation updates an open ticket's priority to the next level up and
-// should cause queue_stats to decrement the old priority bucket and increment
-// the new one simultaneously.
+// Generates ticket lifecycle events to exercise the Streaming Materialized View
+// Pattern implementation in escalation-pipeline.mongodb.js. Includes a fourth
+// event type — priority escalation — which should cause queue_stats to decrement
+// the old priority bucket and increment the new one simultaneously.
 //
 // Event distribution:
 //   32% — open new ticket       (queue_stats increments)

--- a/example_processors/smv/activity/simple-activity.js
+++ b/example_processors/smv/activity/simple-activity.js
@@ -1,12 +1,12 @@
-// activity.js — Support queue activity simulator
+// simple-activity.js — Support queue activity simulator
 //
-// Runs an infinite loop that continuously generates realistic ticket lifecycle
-// events against the support_tickets collection. Each iteration either opens a
-// new ticket, resolves an existing one, adds a support response (noise), or
-// physically deletes a ticket identified as spam or a duplicate.
+// Generates ticket lifecycle events to exercise the Streaming Materialized View
+// Pattern implementation in simple-pipeline.mongodb.js. Each iteration either
+// opens a new ticket, resolves an existing one, adds a support response (noise),
+// or physically deletes a ticket identified as spam or a duplicate.
 //
-// Run this in a DATA PLANE mongosh session alongside watch.js in a second terminal.
-//   mongosh "mongodb+srv://<user>:<pass>@<cluster-host>/" --file streaming/activity.js
+// Run in a DB session alongside watch.mongodb.js in a second terminal:
+//   mongosh "mongodb+srv://<user>:<pass>@<cluster-host>/"
 
 use ('support');
 
@@ -141,7 +141,7 @@ function deleteTicket() {
 
 // -- Loop -------------------------------------------------------------------
 
-print("activity.mongodb.js running — Ctrl+C to stop\n");
+print("simple-activity.js running — Ctrl+C to stop\n");
 
 while (true) {
   const roll = Math.random();

--- a/example_processors/smv/pipelines/escalation-pipeline.mongodb.js
+++ b/example_processors/smv/pipelines/escalation-pipeline.mongodb.js
@@ -1,6 +1,7 @@
-// Streaming Materialized View: Open Ticket Count per Priority (with Escalation)
+// Streaming Materialized View Pattern: Open Ticket Count per Priority (with Escalation)
 //
-// Extends simple-pipeline.mongodb.js to handle priority escalations (e.g. P2 → P1).
+// An implementation of the Streaming Materialized View Pattern that extends
+// simple-pipeline.mongodb.js to handle priority escalations (e.g. P2 → P1).
 // A single change stream event for an escalation must affect two priority buckets
 // simultaneously — decrement the old, increment the new. This requires a different
 // approach to the delta logic.

--- a/example_processors/smv/pipelines/simple-pipeline.mongodb.js
+++ b/example_processors/smv/pipelines/simple-pipeline.mongodb.js
@@ -1,6 +1,7 @@
-// Streaming Materialized View: Open Ticket Count per Priority (Simple)
+// Streaming Materialized View Pattern: Open Ticket Count per Priority (Simple)
 //
-// Maintains a real-time count of open support tickets per priority in
+// A minimal implementation of the Streaming Materialized View Pattern that
+// maintains a running count of open support tickets per priority in
 // the queue_stats collection. Three events are handled:
 //
 //   - New open ticket inserted              → open_count for that priority increments

--- a/example_processors/smv/watch.mongodb.js
+++ b/example_processors/smv/watch.mongodb.js
@@ -1,10 +1,13 @@
 // watch.js — Live queue_stats monitor
 //
-// Polls the queue_stats materialized view every 2 seconds and prints the
-// current open ticket count per priority. Run this in a DATA PLANE mongosh
-// session alongside activity.js in a second terminal.
+// Polls queue_stats every 2 seconds and prints the current open ticket count
+// per priority. queue_stats is a regular MongoDB collection maintained by the
+// Streaming Materialized View Pattern — this is a plain find() query, not a
+// special ASP API. It can be indexed, queried, and used as the backing store
+// for an application like any other collection.
 //
-//   mongosh "mongodb+srv://<user>:<pass>@<cluster-host>/" --file streaming/watch.js
+// Run in a DB session alongside activity.js in a second terminal:
+//   mongosh "mongodb+srv://<user>:<pass>@<cluster-host>/"
 
 use('support');
 


### PR DESCRIPTION
## Summary

- Adds a new `example_processors/smv` example demonstrating the Streaming Materialized View Pattern using Atlas Stream Processing
- Two pipeline variants: `simple-pipeline.mongodb.js` (insert/resolve/delete) and `escalation-pipeline.mongodb.js` (+ priority escalation via `_adjustments` array + `$unwind`)
- Idempotency guaranteed via `lastWindowStart` high-water mark in the `$merge` `whenMatched` pipeline, guarding against at-least-once replay
- Seed script initializes `queue_stats` as a point-in-time snapshot before the processor starts; starting the processor converts it to a continuously maintained view
- Three-session demo architecture: ASP session (processor management), DB session (watch), DB session (activity)
- Activity simulators, reset scripts, and a live bar-chart monitor included
- `queue_stats` is a regular MongoDB collection — indexable, queryable, usable as an app backing store directly

## Test plan

- [ ] Replace `CONNECTION_NAME` in pipeline files with a registered ASP connection name
- [ ] Run Step 1–6 in the README against a live Atlas cluster with ASP enabled
- [ ] Verify `queue_stats` increments on ticket open, decrements on resolve/delete
- [ ] Verify escalation events shift counts between two priority buckets simultaneously
- [ ] Verify `dlqMessageCount` stays at 0 throughout
- [ ] Run reset scripts and confirm clean state for a second run